### PR TITLE
Track clicks for outbound links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,4 +25,3 @@ exclude: [vendor]
 sass:
   style: compressed
 
-

--- a/_config.yml
+++ b/_config.yml
@@ -25,3 +25,4 @@ exclude: [vendor]
 sass:
   style: compressed
 
+

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,7 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics_debug.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-79395723-1', 'auto');
   ga('send', 'pageview');

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,9 +19,9 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics_debug.js','ga');
 
   ga('create', 'UA-79395723-1', 'auto');
   ga('send', 'pageview');
-
 </script>
+<script src="/js/track-outbound-links.js"></script>

--- a/js/track-outbound-links.js
+++ b/js/track-outbound-links.js
@@ -1,0 +1,61 @@
+// Track external file downloads, file downloads and external links in
+// Google Analytics.
+//
+// Based on:
+// http://www.axllent.org/docs/view/track-outbound-links-with-analytics-js/
+//
+// Blog post:
+// https://labs.kollegorna.se/blog/2015/04/google-analytics-track-external-links-downloads/
+
+function _gaLt(event){
+  var el = event.srcElement || event.target;
+
+  // Loop up the tree through parent elements if clicked element is not a link
+  // (eg: an image inside a link).
+  while (el && (typeof el.tagName == 'undefined' || el.tagName.toLowerCase() != 'a' || !el.href)) {
+    el = el.parentNode;
+  }
+
+  if (el && el.href) {
+    var filetypes = /\.(zip|rar|tar|gz|exe|dmg|pdf|doc.*|xls.*|ppt.*|pps.*|vcf|txt|csv|rtf|odt|pages|mp3|wav|wma|mov|avi|wmv|mpg|mp4|flv|png|jpg|jpeg|gif|tif|tiff|bmp|svg|eps|ai|psd)$/i;
+    var referrer = document.location.pathname + document.location.search;
+    var open_link = false;
+
+    if (el.href.match(filetypes)) { // File download
+      if (el.href.indexOf(location.host) == -1) { // External file
+        ga('send', 'event', 'Download external file', el.href, referrer);
+      }
+      else { // Internal file
+        ga('send', 'event', 'Download file', el.pathname, referrer);
+      }
+      open_link = true;
+    }
+    else if (el.href.indexOf(location.host) == -1) { // External link
+      ga('send', 'event', 'External link', el.href, referrer);
+      open_link = true;
+    }
+
+    if (open_link) {
+      setTimeout(function() {
+        window.open(el.href, '_blank');
+      }.bind(el), 500);
+
+      event.preventDefault ? event.preventDefault() : event.returnValue = false;
+    }
+  }
+}
+
+// Attach the event to all clicks in the document after page has loaded.
+if (window.addEventListener) {
+  window.addEventListener('load', function() {
+    document.body.addEventListener('click', _gaLt, false);
+  }, false);
+}
+else {
+  window.attachEvent && window.attachEvent('onload', function() {
+    document.body.attachEvent('onclick', _gaLt);
+  });
+}
+
+// The same attach code as above, minified for minimalists.
+var w=window,b=document.body;w.addEventListener?w.addEventListener('load',function(){b.addEventListener('click',_gaLt,!1)},!1):w.attachEvent&&w.attachEvent('onload',function(){b.attachEvent('onclick',_gaLt)});


### PR DESCRIPTION
This registers when someone clicks on a link going to an external site.

Collecting this data allows us to see where people are going after they hit this page, and to track goals to see how successful our site is at converting readers to followers.